### PR TITLE
Optional을 안티 패턴으로 사용하고 있는 코드 변경

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -191,4 +191,8 @@ public class Auction extends BaseTimeEntity {
 
         return Optional.of(lastBid.getBidder());
     }
+
+    public Optional<Bid> findLastBid() {
+        return Optional.ofNullable(lastBid);
+    }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/application/BidService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/application/BidService.java
@@ -1,10 +1,10 @@
 package com.ddang.ddang.bid.application;
 
-import com.ddang.ddang.auction.infrastructure.persistence.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.dto.AuctionAndImageDto;
 import com.ddang.ddang.auction.domain.repository.AuctionAndImageRepository;
 import com.ddang.ddang.auction.domain.repository.AuctionRepository;
+import com.ddang.ddang.auction.infrastructure.persistence.exception.AuctionNotFoundException;
 import com.ddang.ddang.bid.application.dto.BidDto;
 import com.ddang.ddang.bid.application.dto.CreateBidDto;
 import com.ddang.ddang.bid.application.dto.ReadBidDto;
@@ -19,7 +19,6 @@ import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.domain.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -42,39 +41,35 @@ public class BidService {
         final AuctionAndImageDto auctionAndImageDto =
                 auctionAndImageRepository.findDtoByAuctionId(bidDto.auctionId())
                                          .orElseThrow(() -> new AuctionNotFoundException("해당 경매를 찾을 수 없습니다."));
-
         final Auction auction = auctionAndImageDto.auction();
+
         checkInvalidAuction(auction);
         checkInvalidBid(auction, bidder, bidDto);
 
-        final Optional<User> previousBidder = auction.findLastBidder();
+        auction.findLastBidder()
+               .ifPresent(previousBidder ->
+                       publishBidNotificationEvent(auctionImageAbsoluteUrl, auctionAndImageDto, previousBidder));
 
-        final Bid saveBid = saveAndUpdateLastBid(bidDto, auction, bidder);
-
-        publishBidNotificationEvent(auctionImageAbsoluteUrl, auctionAndImageDto, previousBidder);
-
-        return saveBid.getId();
+        return saveAndUpdateLastBid(bidDto, auction, bidder).getId();
     }
 
     private void publishBidNotificationEvent(
             final String auctionImageAbsoluteUrl,
             final AuctionAndImageDto auctionAndImageDto,
-            final Optional<User> previousBidder
+            final User previousBidder
     ) {
-        if (previousBidder.isEmpty()) {
-            return;
-        }
-
         final BidDto bidDto = new BidDto(
-                previousBidder.get().getId(),
+                previousBidder.getId(),
                 auctionAndImageDto,
                 auctionImageAbsoluteUrl
         );
+
         bidEventPublisher.publishEvent(new BidNotificationEvent(bidDto));
     }
 
     private void checkInvalidAuction(final Auction auction) {
         final LocalDateTime now = LocalDateTime.now();
+
         if (auction.isClosed(now)) {
             throw new InvalidAuctionToBidException("이미 종료된 경매입니다");
         }
@@ -84,18 +79,18 @@ public class BidService {
     }
 
     private void checkInvalidBid(final Auction auction, final User bidder, final CreateBidDto bidDto) {
-        final Optional<Bid> lastBid = bidRepository.findLastBidByAuctionId(bidDto.auctionId());
-        final BidPrice bidPrice = processBidPrice(bidDto.bidPrice());
-
         checkIsSeller(auction, bidder);
 
-        if (lastBid.isPresent()) {
-            checkIsNotLastBidder(lastBid.get(), bidder);
-            checkInvalidBidPrice(lastBid.get(), bidPrice);
-            return;
-        }
+        final BidPrice bidPrice = processBidPrice(bidDto.bidPrice());
 
-        checkInvalidFirstBidPrice(auction, bidPrice);
+        auction.findLastBid()
+                .ifPresentOrElse(
+                        lastBid -> {
+                            checkIsNotLastBidder(lastBid, bidder);
+                            checkInvalidBidPrice(lastBid, bidPrice);
+                        },
+                        () -> checkInvalidFirstBidPrice(auction, bidPrice)
+                );
     }
 
     private BidPrice processBidPrice(final int value) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/device/domain/DeviceToken.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/device/domain/DeviceToken.java
@@ -39,11 +39,11 @@ public class DeviceToken {
         this.deviceToken = deviceToken;
     }
 
-    public boolean isDifferentToken(final String targetDeviceToken) {
-        return !this.deviceToken.equals(targetDeviceToken);
+    public boolean isDifferentToken(final String targetDeviceTokenValue) {
+        return !this.deviceToken.equals(targetDeviceTokenValue);
     }
 
-    public void updateDeviceToken(final String newDeviceToken) {
-        this.deviceToken = newDeviceToken;
+    public void updateDeviceToken(final String newDeviceTokenValue) {
+        this.deviceToken = newDeviceTokenValue;
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
@@ -420,4 +420,42 @@ class AuctionTest extends AuctionFixture {
         // then
         assertThat(actual).isEqualTo(AuctionStatus.SUCCESS);
     }
+
+    @Test
+    void 마지막_입찰_내역이_있으면_Optional로_감싸서_반환한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("제목")
+                                       .seller(판매자)
+                                       .closingTime(LocalDateTime.now().minusDays(2))
+                                       .build();
+        final Bid bid = new Bid(auction, 구매자, 유효한_입찰_금액);
+
+        auction.updateLastBid(bid);
+
+        // when
+        final Optional<Bid> actual = auction.findLastBid();
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isPresent();
+            softAssertions.assertThat(actual.get()).isEqualTo(bid);
+        });
+    }
+
+    @Test
+    void 마지막_입찰_내역이_없다면_빈_Optional을_반환한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("제목")
+                                       .seller(판매자)
+                                       .closingTime(LocalDateTime.now().minusDays(2))
+                                       .build();
+
+        // when
+        final Optional<Bid> actual = auction.findLastBid();
+
+        // then
+        assertThat(actual).isEmpty();
+    }
 }


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->

### 변경한 부분

#### BidService

- publishBidNotificationEvent()
  - Optional을 null처럼 사용하던 로직 변경
- checkInvalidBid() 
  - Optional을 null처럼 사용하던 로직 변경 
  - 비정규화를 적용했음에도 불구하고 별도의 쿼리를 한 번 더 전송하던 로직 삭제 
    - 이 과정에서 Auction 도메인 엔티티에 lastBid를 조회하는 로직 추가

#### ChatRoomService

- readChatInfoByAuctionId()
  - Optional을 null처럼 사용하던 로직 변경

#### DeviceToken

- persist()
  - Optionial을 제대로 사용하지 못해 필요 없는 분기 처리가 되는 로직을 변경

### 변경하지 못한 부분

#### ImageService

- readProfileImage() / readAuctionImage()
  - UrlResource()를 반환해야하므로 Checked Exception을 처리하는 과정에서 가독성의 하락이 발생
  - Checked Exception을 Unchecked Exception으로 변환하는 경우 읽기 전용 트랜잭션에서 불필요하게 롤백이 발생할 가능성이 생김

#### QuestionService

- readAllByAuctionId()
  - ifPresentOrElse()로 할 수 있으나 이 경우 ReadQnasDto.of() 코드가 반복됨
  - 가독성 하락 
  - user만 변경되므로 UserRepository 조회에서 orElse()를 통해 기본 값(User.EMPTY_USER)를 세팅하는 것이 가독성이 더 좋음 

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #2 
<!-- closed #번호 --> 
