### PR TITLE
소셜 로그인 시 외부 로직과 비즈니스 로직의 분리

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/SocialUserInformationService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/SocialUserInformationService.java
@@ -1,0 +1,23 @@
+package com.ddang.ddang.authentication.application;
+
+import com.ddang.ddang.authentication.application.dto.SocialUserInformationDto;
+import com.ddang.ddang.authentication.domain.Oauth2UserInformationProviderComposite;
+import com.ddang.ddang.authentication.domain.dto.UserInformationDto;
+import com.ddang.ddang.authentication.infrastructure.oauth2.OAuth2UserInformationProvider;
+import com.ddang.ddang.authentication.infrastructure.oauth2.Oauth2Type;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SocialUserInformationService {
+
+    private final Oauth2UserInformationProviderComposite providerComposite;
+
+    public SocialUserInformationDto findInformation(final Oauth2Type oauth2Type, final String oauth2AccessToken) {
+        final OAuth2UserInformationProvider provider = providerComposite.findProvider(oauth2Type);
+        final UserInformationDto userInformation = provider.findUserInformation(oauth2AccessToken);
+
+        return SocialUserInformationDto.from(userInformation);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/dto/SocialUserInformationDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/dto/SocialUserInformationDto.java
@@ -1,0 +1,10 @@
+package com.ddang.ddang.authentication.application.dto;
+
+import com.ddang.ddang.authentication.domain.dto.UserInformationDto;
+
+public record SocialUserInformationDto(String id) {
+
+    public static SocialUserInformationDto from(final UserInformationDto dto) {
+        return new SocialUserInformationDto(dto.findUserId());
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/authentication/presentation/AuthenticationController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/authentication/presentation/AuthenticationController.java
@@ -2,7 +2,9 @@ package com.ddang.ddang.authentication.presentation;
 
 import com.ddang.ddang.authentication.application.AuthenticationService;
 import com.ddang.ddang.authentication.application.BlackListTokenService;
+import com.ddang.ddang.authentication.application.SocialUserInformationService;
 import com.ddang.ddang.authentication.application.dto.LoginInformationDto;
+import com.ddang.ddang.authentication.application.dto.SocialUserInformationDto;
 import com.ddang.ddang.authentication.application.dto.TokenDto;
 import com.ddang.ddang.authentication.infrastructure.oauth2.Oauth2Type;
 import com.ddang.ddang.authentication.presentation.dto.request.LoginTokenRequest;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthenticationController {
 
     private final AuthenticationService authenticationService;
+    private final SocialUserInformationService socialUserInformationService;
     private final BlackListTokenService blackListTokenService;
 
     @PostMapping("/login/{oauth2Type}")
@@ -37,8 +40,10 @@ public class AuthenticationController {
             @PathVariable final Oauth2Type oauth2Type,
             @RequestBody final LoginTokenRequest request
     ) {
+        final SocialUserInformationDto socialUserInformationDto =
+                socialUserInformationService.findInformation(oauth2Type, request.accessToken());
         final LoginInformationDto loginInformationDto =
-                authenticationService.login(oauth2Type, request.accessToken(), request.deviceToken());
+                authenticationService.login(socialUserInformationDto.id(), oauth2Type, request.deviceToken());
 
         return ResponseEntity.ok(LoginInformationResponse.from(loginInformationDto));
     }

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/AuthenticationServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/AuthenticationServiceTest.java
@@ -1,5 +1,10 @@
 package com.ddang.ddang.authentication.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
 import com.ddang.ddang.auction.domain.repository.AuctionRepository;
 import com.ddang.ddang.authentication.application.dto.LoginInformationDto;
 import com.ddang.ddang.authentication.application.dto.TokenDto;
@@ -10,7 +15,6 @@ import com.ddang.ddang.authentication.domain.Oauth2UserInformationProviderCompos
 import com.ddang.ddang.authentication.domain.TokenDecoder;
 import com.ddang.ddang.authentication.domain.TokenEncoder;
 import com.ddang.ddang.authentication.domain.exception.InvalidTokenException;
-import com.ddang.ddang.authentication.domain.exception.UnsupportedSocialLoginException;
 import com.ddang.ddang.authentication.infrastructure.oauth2.OAuth2UserInformationProvider;
 import com.ddang.ddang.configuration.IsolateDatabase;
 import com.ddang.ddang.device.application.DeviceTokenService;
@@ -23,11 +27,6 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -84,8 +83,11 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
         given(userInfoProvider.findUserInformation(anyString())).willReturn(가입하지_않은_사용자_회원_정보);
 
         // when
-        final LoginInformationDto actual = authenticationService.login(지원하는_소셜_로그인_타입, 유효한_소셜_로그인_토큰, 디바이스_토큰);
-
+        final LoginInformationDto actual = authenticationService.login(
+                가입하지_않은_사용자_회원_정보.findUserId(),
+                지원하는_소셜_로그인_타입,
+                디바이스_토큰
+        );
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -95,37 +97,17 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
     }
 
     @Test
-    void 지원하는_소셜_로그인_기능이_아닌_경우_예외가_발생한다() {
-        // given
-        given(providerComposite.findProvider(지원하지_않는_소셜_로그인_타입))
-                .willThrow(new UnsupportedSocialLoginException("지원하는 소셜 로그인 기능이 아닙니다."));
-
-        // when & then
-        assertThatThrownBy(() -> authenticationService.login(지원하지_않는_소셜_로그인_타입, 유효한_소셜_로그인_토큰, 디바이스_토큰))
-                .isInstanceOf(UnsupportedSocialLoginException.class)
-                .hasMessage("지원하는 소셜 로그인 기능이 아닙니다.");
-    }
-
-    @Test
-    void 권한이_없는_소셜_로그인_토큰을_전달하면_예외가_발생한다() {
-        // given
-        given(providerComposite.findProvider(지원하는_소셜_로그인_타입)).willReturn(userInfoProvider);
-        given(userInfoProvider.findUserInformation(anyString())).willThrow(new InvalidTokenException("401 Unauthorized"));
-
-        // when & then
-        assertThatThrownBy(() -> authenticationService.login(지원하지_않는_소셜_로그인_타입, 유효한_소셜_로그인_토큰, 디바이스_토큰))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessage("401 Unauthorized");
-    }
-
-    @Test
     void 가입한_회원이_소셜_로그인을_할_경우_accessToken과_refreshToken을_반환한다() {
         // given
         given(providerComposite.findProvider(지원하는_소셜_로그인_타입)).willReturn(userInfoProvider);
         given(userInfoProvider.findUserInformation(anyString())).willReturn(가입한_사용자_회원_정보);
 
         // when
-        final LoginInformationDto actual = authenticationService.login(지원하는_소셜_로그인_타입, 유효한_소셜_로그인_토큰, 디바이스_토큰);
+        final LoginInformationDto actual = authenticationService.login(
+                가입한_사용자_회원_정보.findUserId(),
+                지원하는_소셜_로그인_타입,
+                디바이스_토큰
+        );
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -142,30 +124,17 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
         given(userInfoProvider.findUserInformation(anyString())).willReturn(가입하지_않은_사용자_회원_정보);
 
         // when
-        final LoginInformationDto actual = authenticationService.login(지원하는_소셜_로그인_타입, 유효한_소셜_로그인_토큰, 디바이스_토큰);
+        final LoginInformationDto actual = authenticationService.login(
+                가입하지_않은_사용자_회원_정보.findUserId(),
+                지원하는_소셜_로그인_타입,
+                디바이스_토큰
+        );
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.tokenDto().accessToken()).isNotEmpty();
             softAssertions.assertThat(actual.tokenDto().refreshToken()).isNotEmpty();
             softAssertions.assertThat(actual.isSignUpUser()).isTrue();
-        });
-    }
-
-    @Test
-    void 탈퇴한_회원이_소셜_로그인을_할_경우_accessToken과_refreshToken을_반환한다() {
-        // given
-        given(providerComposite.findProvider(지원하는_소셜_로그인_타입)).willReturn(userInfoProvider);
-        given(userInfoProvider.findUserInformation(anyString())).willReturn(가입한_사용자_회원_정보);
-
-        // when
-        final LoginInformationDto actual = authenticationService.login(지원하는_소셜_로그인_타입, 유효한_소셜_로그인_토큰, 디바이스_토큰);
-
-        // then
-        SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual.tokenDto().accessToken()).isNotEmpty();
-            softAssertions.assertThat(actual.tokenDto().refreshToken()).isNotEmpty();
-            softAssertions.assertThat(actual.isSignUpUser()).isFalse();
         });
     }
 
@@ -248,7 +217,8 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
     void 존재하지_않는_회원이_탈퇴하는_경우_예외가_발생한다() {
         // given
         given(providerComposite.findProvider(지원하는_소셜_로그인_타입)).willReturn(userInfoProvider);
-        given(userInfoProvider.findUserInformation(anyString())).willThrow(new InvalidTokenException("401 Unauthorized"));
+        given(userInfoProvider.findUserInformation(anyString())).willThrow(
+                new InvalidTokenException("401 Unauthorized"));
 
         // when & then
         assertThatThrownBy(() -> authenticationService.withdrawal(존재하지_않는_사용자_액세스_토큰, 유효한_리프레시_토큰))
@@ -271,7 +241,8 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
         given(userInfoProvider.findUserInformation(anyString())).willReturn(현재_진행중인_경매가_있는_사용자_회원_정보);
 
         // when & then
-        assertThatThrownBy(() -> authenticationService.withdrawal(현재_진행중인_경매가_있는_사용자_액세스_토큰, 현재_진행중인_경매가_있는_사용자_리프래시_토큰))
+        assertThatThrownBy(
+                () -> authenticationService.withdrawal(현재_진행중인_경매가_있는_사용자_액세스_토큰, 현재_진행중인_경매가_있는_사용자_리프래시_토큰))
                 .isInstanceOf(WithdrawalNotAllowedException.class)
                 .hasMessage("등록한 경매 중 현재 진행 중인 것이 있기에 탈퇴할 수 없습니다.");
     }
@@ -283,7 +254,8 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
         given(userInfoProvider.findUserInformation(anyString())).willReturn(현재_진행중인_경매가_있는_사용자_회원_정보);
 
         // when & then
-        assertThatThrownBy(() -> authenticationService.withdrawal(현재_진행중인_경매의_마지막_입찰자인_사용자_액세스_토큰, 현재_진행중인_경매의_마지막_입찰자인_사용자_리프래시_토큰))
+        assertThatThrownBy(() -> authenticationService.withdrawal(현재_진행중인_경매의_마지막_입찰자인_사용자_액세스_토큰,
+                현재_진행중인_경매의_마지막_입찰자인_사용자_리프래시_토큰))
                 .isInstanceOf(WithdrawalNotAllowedException.class)
                 .hasMessage("마지막 입찰자로 등록되어 있는 것이 있기에 탈퇴할 수 없습니다.");
     }

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/SocialUserInformationServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/SocialUserInformationServiceTest.java
@@ -1,0 +1,83 @@
+package com.ddang.ddang.authentication.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.ddang.ddang.authentication.application.dto.SocialUserInformationDto;
+import com.ddang.ddang.authentication.application.fixture.SocialUserInformationServiceFixture;
+import com.ddang.ddang.authentication.domain.Oauth2UserInformationProviderComposite;
+import com.ddang.ddang.authentication.domain.exception.InvalidTokenException;
+import com.ddang.ddang.authentication.domain.exception.UnsupportedSocialLoginException;
+import com.ddang.ddang.authentication.infrastructure.oauth2.OAuth2UserInformationProvider;
+import com.ddang.ddang.configuration.IsolateDatabase;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class SocialUserInformationServiceTest extends SocialUserInformationServiceFixture {
+
+    @MockBean
+    Oauth2UserInformationProviderComposite providerComposite;
+
+    @MockBean
+    OAuth2UserInformationProvider userInfoProvider;
+
+    @Autowired
+    SocialUserInformationService socialUserInformationService;
+
+    @Test
+    void 지원하는_소셜_로그인_타입으로_유효한_토큰을_전달하면_사용자의_소셜_정보를_반환한다() {
+        // given
+        given(providerComposite.findProvider(지원하는_소셜_로그인_타입)).willReturn(userInfoProvider);
+        given(userInfoProvider.findUserInformation(anyString())).willReturn(사용자_소셜_정보);
+
+        // when
+        final SocialUserInformationDto actual = socialUserInformationService.findInformation(
+                지원하는_소셜_로그인_타입,
+                유효한_소셜_로그인_토큰
+        );
+
+        // then
+        assertThat(actual.id()).isEqualTo(사용자_소셜_정보.findUserId());
+    }
+
+    @Test
+    void 권한이_없는_소셜_로그인_토큰을_전달하면_예외가_발생한다() {
+        // given
+        given(providerComposite.findProvider(지원하는_소셜_로그인_타입)).willReturn(userInfoProvider);
+        given(userInfoProvider.findUserInformation(anyString())).willThrow(new InvalidTokenException("401 Unauthorized"));
+
+        // when & then
+        assertThatThrownBy(
+                () -> socialUserInformationService.findInformation(
+                        지원하는_소셜_로그인_타입,
+                        권한이_없는_소셜_로그인_토큰
+                )
+        ).isInstanceOf(InvalidTokenException.class)
+         .hasMessage("401 Unauthorized");
+    }
+
+    @Test
+    void 지원하는_소셜_로그인_기능이_아닌_경우_예외가_발생한다() {
+        // given
+        given(providerComposite.findProvider(지원하지_않는_소셜_로그인_타입))
+                .willThrow(new UnsupportedSocialLoginException("지원하는 소셜 로그인 기능이 아닙니다."));
+
+        // when & then
+        assertThatThrownBy(
+                () -> socialUserInformationService.findInformation(
+                        지원하지_않는_소셜_로그인_타입,
+                        유효한_소셜_로그인_토큰
+                )
+        )
+                .isInstanceOf(UnsupportedSocialLoginException.class)
+                .hasMessage("지원하는 소셜 로그인 기능이 아닙니다.");
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/AuthenticationServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/AuthenticationServiceFixture.java
@@ -101,7 +101,7 @@ public class AuthenticationServiceFixture {
                       .name("kakao12346")
                       .profileImage(new ProfileImage("upload.png", "store.png"))
                       .reliability(new Reliability(0.0d))
-                      .oauthId("12346")
+                      .oauthId(탈퇴한_사용자_회원_정보.findUserId())
                       .oauth2Type(Oauth2Type.KAKAO)
                       .build();
         final User 현재_진행중인_경매가_있는_사용자 = User.builder()

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/SocialUserInformationServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/SocialUserInformationServiceFixture.java
@@ -1,0 +1,14 @@
+package com.ddang.ddang.authentication.application.fixture;
+
+import com.ddang.ddang.authentication.domain.dto.UserInformationDto;
+import com.ddang.ddang.authentication.infrastructure.oauth2.Oauth2Type;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class SocialUserInformationServiceFixture {
+
+    protected Oauth2Type 지원하는_소셜_로그인_타입 = Oauth2Type.KAKAO;
+    protected Oauth2Type 지원하지_않는_소셜_로그인_타입 = Oauth2Type.KAKAO;
+    protected String 유효한_소셜_로그인_토큰 = "Bearer accessToken";
+    protected String 권한이_없는_소셜_로그인_토큰 = "Bearer no authorization";
+    protected UserInformationDto 사용자_소셜_정보 = new UserInformationDto(1L);
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/presentation/AuthenticationControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/presentation/AuthenticationControllerTest.java
@@ -59,7 +59,8 @@ class AuthenticationControllerTest extends AuthenticationControllerFixture {
     @Test
     void 소셜_로그인을_지원하는_타입과_소셜_로그인_토큰을_전달하면_accessToken과_refreshToken을_반환한다() throws Exception {
         // given
-        given(authenticationService.login(eq(지원하는_소셜_로그인_타입), anyString(), anyString())).willReturn(로그인한_사용자_정보);
+        given(socialUserInformationService.findInformation(eq(지원하는_소셜_로그인_타입), anyString())).willReturn(회원_소셜_정보);
+        given(authenticationService.login(anyString(), eq(지원하는_소셜_로그인_타입), anyString())).willReturn(로그인한_사용자_정보);
 
         // when & then
         final ResultActions resultActions =
@@ -80,7 +81,7 @@ class AuthenticationControllerTest extends AuthenticationControllerFixture {
     @Test
     void 소셜_로그인을_진행하지_않는_타입을_전달하면_400이_발생한다() throws Exception {
         // given
-        given(authenticationService.login(eq(지원하지_않는_소셜_로그인_타입), anyString(), anyString()))
+        given(socialUserInformationService.findInformation(eq(지원하지_않는_소셜_로그인_타입), anyString()))
                 .willThrow(new UnsupportedSocialLoginException("지원하는 소셜 로그인 기능이 아닙니다."));
 
         // when & then
@@ -97,7 +98,7 @@ class AuthenticationControllerTest extends AuthenticationControllerFixture {
     @Test
     void 유효하지_않은_소셜_로그인_토큰을_전달하면_401이_발생한다() throws Exception {
         // given
-        given(authenticationService.login(eq(지원하는_소셜_로그인_타입), anyString(), anyString()))
+        given(socialUserInformationService.findInformation(eq(지원하는_소셜_로그인_타입), anyString()))
                 .willThrow(new InvalidTokenException("401 Unauthorized", new RuntimeException()));
 
         // when & then

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/presentation/fixture/AuthenticationControllerFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/presentation/fixture/AuthenticationControllerFixture.java
@@ -1,6 +1,7 @@
 package com.ddang.ddang.authentication.presentation.fixture;
 
 import com.ddang.ddang.authentication.application.dto.LoginInformationDto;
+import com.ddang.ddang.authentication.application.dto.SocialUserInformationDto;
 import com.ddang.ddang.authentication.application.dto.TokenDto;
 import com.ddang.ddang.authentication.infrastructure.oauth2.Oauth2Type;
 import com.ddang.ddang.authentication.presentation.dto.request.LoginTokenRequest;
@@ -26,4 +27,5 @@ public class AuthenticationControllerFixture extends CommonControllerSliceTest {
     protected LogoutRequest 유효한_로그아웃_요청 = new LogoutRequest("Bearer refreshToken");
     protected WithdrawalRequest 유효한_회원탈퇴_요청 = new WithdrawalRequest("Bearer refreshToken");
     protected WithdrawalRequest 유효하지_않은_회원탈퇴_요청 = new WithdrawalRequest("Bearer refreshToken");
+    protected SocialUserInformationDto 회원_소셜_정보 = new SocialUserInformationDto("12345");
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/configuration/CommonControllerSliceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/configuration/CommonControllerSliceTest.java
@@ -7,6 +7,7 @@ import com.ddang.ddang.auction.presentation.AuctionReviewController;
 import com.ddang.ddang.authentication.application.AuthenticationService;
 import com.ddang.ddang.authentication.application.AuthenticationUserService;
 import com.ddang.ddang.authentication.application.BlackListTokenService;
+import com.ddang.ddang.authentication.application.SocialUserInformationService;
 import com.ddang.ddang.authentication.presentation.AuthenticationController;
 import com.ddang.ddang.bid.application.BidService;
 import com.ddang.ddang.bid.presentation.BidController;
@@ -186,4 +187,7 @@ public abstract class CommonControllerSliceTest {
 
     @MockBean
     protected ReviewService reviewService;
+
+    @MockBean
+    protected SocialUserInformationService socialUserInformationService;
 }


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
소셜 로그인을 위해 외부에 요청하는 로직과 내부 비즈니스 로직을 분리했습니다

### 변경사항

- SocialUserInformationService 추가
- AuthenticationController에서 SocialUserInformationService을 의존해 소셜 정보를 조회하도록 변경 
- 관련 테스트 변경
  - 컨트롤러 슬라이스 테스트에서 MockBean으로 SocialUserInformationService 등록, mocking 과정 추가
  - AuthenticationServiceTest에서 외부 요청 과정을 테스트하는 테스트 케이스를 SocialUserInformationService로 이동
  - 일부 잘못된 테스트 로직 및 Fixture 수정

### 고려사항

파사드 패턴을 서비스에서 도입할지 고민했습니다만 아직 서비스 쪽 로직이 그렇게까지 복잡하지는 않다고 판단했습니다 
그래서 단순하게 컨트롤러에서 두 서비스를 의존하면서 호출하도록 처리했습니다 

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #7 
<!-- closed #번호 --> 
