### PR TITLE
DB 격리 시 불필요하게 객체를 생성하던 로직 변경

### DIFF
--- a/backend/ddang/src/test/java/com/ddang/ddang/configuration/DatabaseCleanListener.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/configuration/DatabaseCleanListener.java
@@ -49,13 +49,21 @@ public class DatabaseCleanListener extends AbstractTestExecutionListener {
 
     private void clean(final EntityManager em, final List<String> tableNames) {
         em.flush();
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        final StringBuilder sb = new StringBuilder("SET REFERENTIAL_INTEGRITY FALSE;");
 
         for (final String tableName : tableNames) {
-            em.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            em.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN id RESTART WITH 1").executeUpdate();
+            sb.append("TRUNCATE TABLE ")
+              .append(tableName)
+              .append(";");
+
+            sb.append("ALTER TABLE ")
+              .append(tableName)
+              .append(" ALTER COLUMN id RESTART WITH 1;");
         }
 
-        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        sb.append("SET REFERENTIAL_INTEGRITY TRUE;");
+
+        em.createNativeQuery(sb.toString()).executeUpdate();
     }
 }


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
DB 격리 시 불필요하게 객체를 생성하던 로직 변경

[TestExecutionListener 사용 시 OutOfMemoryError 발생 트러블슈팅](https://velog.io/@appti/TestExecutionListener-%EC%82%AC%EC%9A%A9-%EC%8B%9C-%EB%B0%9C%EC%83%9D%ED%95%98%EB%8A%94-OutOfMemory) 참고
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #27 
<!-- closed #번호 --> 
